### PR TITLE
prevent invites and acceptance if team is full; refactor team invite …

### DIFF
--- a/api/src/team/team.controller.ts
+++ b/api/src/team/team.controller.ts
@@ -135,6 +135,8 @@ export class TeamController {
     @Body() inviteUserDto: InviteUserDto,
     @Team() team: TeamEntity,
   ) {
+    if(await this.teamService.isTeamFull(team.id))
+        throw new BadRequestException("This team is full.");
     if (
       await this.teamService.getTeamOfUserForEvent(
         eventId,
@@ -193,6 +195,8 @@ export class TeamController {
       );
     if (!(await this.teamService.isUserInvitedToTeam(userId, teamId)))
       throw new BadRequestException("You are not invited to this team.");
+      if(await this.teamService.isTeamFull(teamId))
+          throw new BadRequestException("This team is full.");
 
     return this.teamService.acceptTeamInvite(userId, teamId);
   }

--- a/api/src/team/team.service.ts
+++ b/api/src/team/team.service.ts
@@ -492,6 +492,23 @@ export class TeamService {
     });
   }
 
+    async isTeamFull(teamId: string) {
+        const team = await this.teamRepository.findOne({
+            where: {
+                id: teamId,
+            },
+            relations: {
+                event: true,
+                users: true
+            }
+        });
+        const maxUsers = team?.event.maxTeamSize;
+        if (!maxUsers) return true;
+        if (!team?.users) return true;
+
+        return team?.users.length >= maxUsers;
+    }
+
   async leaveQueue(teamId: string) {
     return this.teamRepository.update(teamId, { inQueue: false });
   }

--- a/frontend/app/actions/team.ts
+++ b/frontend/app/actions/team.ts
@@ -161,21 +161,6 @@ export async function searchUsersForInvite(
 }
 
 /**
- * Send a team invite to a user
- * @returns boolean indicating success
- * @param eventId
- * @param userId ID of the user to invite
- */
-export async function sendTeamInvite(
-  eventId: string,
-  userId: string,
-): Promise<void> {
-  await axiosInstance.post(`team/event/${eventId}/sendInvite`, {
-    userToInviteId: userId,
-  });
-}
-
-/**
  * Get pending team invites for a user
  * @returns Array of team invites with details
  * @param eventId

--- a/frontend/components/team/TeamInviteModal.tsx
+++ b/frontend/components/team/TeamInviteModal.tsx
@@ -6,7 +6,6 @@ import { usePlausible } from "next-plausible";
 import { useEffect, useState } from "react";
 import {
   searchUsersForInvite,
-  sendTeamInvite,
 } from "@/app/actions/team";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
@@ -21,6 +20,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import axiosInstance from "@/app/actions/axios";
+import {toast} from "sonner";
 
 interface TeamInviteModalProps {
   isOpen: boolean;
@@ -61,7 +62,9 @@ export function TeamInviteModal({
     plausible("invite_team_member");
     setIsInviting(prev => ({ ...prev, [userId]: true }));
     try {
-      await sendTeamInvite(eventId, userId);
+      await axiosInstance.post(`team/event/${eventId}/sendInvite`, {
+        userToInviteId: userId,
+      });
 
       setSearchResults(prev =>
         prev.map(user =>
@@ -70,8 +73,7 @@ export function TeamInviteModal({
       );
     }
     catch (error: any) {
-      // eslint-disable-next-line no-alert
-      alert(
+      toast.error(
         error?.response?.data?.message
         || error?.message
         || "Failed to send invite.",


### PR DESCRIPTION
…logic in frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents sending team invites when the team has reached its maximum size, with a clear error message.
  - Blocks accepting invites to full teams, ensuring team size limits are respected.
  - Replaces browser alerts with in-app toast notifications for invite errors, providing clearer, non-intrusive feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->