### PR TITLE
Refresh bracket and group data when returning from match views.

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.env.example
+.gitignore

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  glob: ^9.3.5
-
 importers:
 
   .:
@@ -610,6 +607,10 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -770,42 +771,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -1019,6 +1027,10 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -1076,36 +1088,42 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.21':
     resolution: {integrity: sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.21':
     resolution: {integrity: sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.21':
     resolution: {integrity: sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.21':
     resolution: {integrity: sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.21':
     resolution: {integrity: sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.21':
     resolution: {integrity: sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ==}
@@ -1353,6 +1371,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1393,41 +1412,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1621,6 +1648,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1628,6 +1659,10 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
@@ -2129,6 +2164,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -2147,6 +2185,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -2404,6 +2445,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fork-ts-checker-webpack-plugin@9.1.0:
     resolution: {integrity: sha512-mpafl89VFPJmhnJ1ssH+8wmM2b50n+Rew5x42NeI2U78aRWgtkEtGmctp7iT16UjquJTjorEmIfESj3DxdW84Q==}
     engines: {node: '>=14.21.3'}
@@ -2480,9 +2525,17 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  glob@9.3.5:
-    resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  glob@13.0.0:
+    resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
+    engines: {node: 20 || >=22}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
@@ -2577,6 +2630,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -2666,6 +2723,9 @@ packages:
   iterare@1.2.1:
     resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
     engines: {node: '>=6'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jest-changed-files@30.3.0:
     resolution: {integrity: sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==}
@@ -2934,6 +2994,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3025,20 +3089,12 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@8.0.7:
-    resolution: {integrity: sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  minipass@4.2.8:
-    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
-    engines: {node: '>=8'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -3161,6 +3217,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3196,6 +3255,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -3203,6 +3266,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
@@ -3602,12 +3669,20 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -4019,6 +4094,10 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -4531,6 +4610,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
       camelcase: 5.3.1
@@ -4642,7 +4730,7 @@ snapshots:
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
-      glob: 9.3.5
+      glob: 10.5.0
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.3
@@ -4842,7 +4930,7 @@ snapshots:
       cli-table3: 0.6.5
       commander: 4.1.1
       fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.21))
-      glob: 9.3.5
+      glob: 13.0.0
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
@@ -5000,6 +5088,9 @@ snapshots:
       '@noble/hashes': 1.8.0
 
   '@pinojs/redact@0.4.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@pkgr/core@0.2.9': {}
 
@@ -5692,11 +5783,15 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   ansis@4.2.0: {}
 
@@ -6159,6 +6254,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -6172,6 +6269,8 @@ snapshots:
   emittery@0.13.1: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -6479,6 +6578,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.21)):
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -6563,12 +6667,29 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
-  glob@9.3.5:
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  glob@13.0.0:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
-      minimatch: 8.0.7
-      minipass: 4.2.8
-      path-scurry: 1.11.1
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
 
   globals@14.0.0: {}
 
@@ -6660,6 +6781,11 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
   inherits@2.0.4: {}
 
   inspect-with-kind@1.0.5:
@@ -6735,6 +6861,12 @@ snapshots:
 
   iterare@1.2.1: {}
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jest-changed-files@30.3.0:
     dependencies:
       execa: 5.1.1
@@ -6797,7 +6929,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.4.0
       deepmerge: 4.3.1
-      glob: 9.3.5
+      glob: 10.5.0
       graceful-fs: 4.2.11
       jest-circus: 30.3.0
       jest-docblock: 30.2.0
@@ -6956,7 +7088,7 @@ snapshots:
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
-      glob: 9.3.5
+      glob: 10.5.0
       graceful-fs: 4.2.11
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
@@ -7169,6 +7301,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -7238,17 +7372,11 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@8.0.7:
-    dependencies:
-      brace-expansion: 2.0.2
-
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
-
-  minipass@4.2.8: {}
 
   minipass@7.1.3: {}
 
@@ -7357,6 +7485,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -7397,11 +7527,18 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-is-absolute@1.0.1: {}
+
   path-key@3.1.1: {}
 
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
       minipass: 7.1.3
 
   path-to-regexp@8.3.0: {}
@@ -7811,6 +7948,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -7818,6 +7961,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -7918,7 +8065,7 @@ snapshots:
   test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      glob: 9.3.5
+      glob: 7.2.3
       minimatch: 3.1.5
 
   text-decoder@1.2.7:
@@ -8070,7 +8217,7 @@ snapshots:
       debug: 4.4.3
       dedent: 1.7.2
       dotenv: 16.6.1
-      glob: 9.3.5
+      glob: 10.5.0
       reflect-metadata: 0.2.2
       sha.js: 2.4.12
       sql-highlight: 6.1.0
@@ -8254,6 +8401,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 

--- a/api/pnpm-workspace.yaml
+++ b/api/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+allowBuilds:
+  '@nestjs/core': true
+  '@scarf/scarf': true
+  '@swc/core': true
+  unrs-resolver: true
 onlyBuiltDependencies:
   - '@nestjs/core'
   - '@scarf/scarf'

--- a/frontend/app/events/[id]/bracket/BracketTabs.tsx
+++ b/frontend/app/events/[id]/bracket/BracketTabs.tsx
@@ -1,29 +1,83 @@
 "use client";
 
-import type { Team } from "@/app/actions/team";
-import type { Match } from "@/app/actions/tournament-model";
+import { useQuery } from "@tanstack/react-query";
 import { BarChart3, Network } from "lucide-react";
+import { useMemo } from "react";
+import {
+  eventTeamsStandingsQueryFn,
+  eventTeamsStandingsQueryKey,
+  tournamentMatchesQueryFn,
+  tournamentMatchesQueryKey,
+  tournamentTeamCountQueryFn,
+  tournamentTeamCountQueryKey,
+} from "@/app/events/[id]/tournament-queries";
+import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useInvalidateOnMatchReturn } from "@/hooks/useInvalidateOnMatchReturn";
 import { useTabParam } from "@/hooks/useTabParam";
 import BracketRankingTable from "./BracketRankingTable";
 import GraphView from "./graphView";
 
 interface BracketTabsProps {
   eventId: string;
-  matches: Match[];
-  teams: Team[];
   isEventAdmin: boolean;
-  teamCount: number;
+  adminReveal: boolean;
 }
 
 export default function BracketTabs({
   eventId,
-  matches,
-  teams,
   isEventAdmin,
-  teamCount,
+  adminReveal,
 }: BracketTabsProps) {
+  const queryKeys = useMemo(
+    () => [
+      tournamentMatchesQueryKey(eventId, adminReveal),
+      tournamentTeamCountQueryKey(eventId),
+      eventTeamsStandingsQueryKey(eventId, adminReveal),
+    ],
+    [eventId, adminReveal],
+  );
+
+  useInvalidateOnMatchReturn(queryKeys);
   const { currentTab, onTabChange } = useTabParam("graph");
+  const matchesQuery = useQuery({
+    queryKey: tournamentMatchesQueryKey(eventId, adminReveal),
+    queryFn: () => tournamentMatchesQueryFn(eventId, adminReveal),
+  });
+  const teamCountQuery = useQuery({
+    queryKey: tournamentTeamCountQueryKey(eventId),
+    queryFn: () => tournamentTeamCountQueryFn(eventId),
+  });
+  const teamsQuery = useQuery({
+    queryKey: eventTeamsStandingsQueryKey(eventId, adminReveal),
+    queryFn: () => eventTeamsStandingsQueryFn(eventId, adminReveal),
+  });
+
+  const matches = matchesQuery.data;
+  const teamCount = teamCountQuery.data;
+  const teams = teamsQuery.data;
+  const isLoading = [matchesQuery, teamCountQuery, teamsQuery].some(
+    query => query.isPending && query.data === undefined,
+  );
+  const hasError = [matchesQuery, teamCountQuery, teamsQuery].some(
+    query => query.isError && query.data === undefined,
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[320px] items-center justify-center rounded-xl border bg-card/50">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (hasError || !matches || teamCount === undefined || !teams) {
+    return (
+      <div className="rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-6 text-sm text-destructive">
+        Failed to load tournament bracket data.
+      </div>
+    );
+  }
 
   return (
     <Tabs value={currentTab} onValueChange={onTabChange} className="w-full">

--- a/frontend/app/events/[id]/bracket/graphView.tsx
+++ b/frontend/app/events/[id]/bracket/graphView.tsx
@@ -1,11 +1,12 @@
 "use client";
 import type { Edge, Node } from "reactflow";
 import type { Match } from "@/app/actions/tournament-model";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import ReactFlow, { Background, useEdgesState, useNodesState } from "reactflow";
 import { MatchState } from "@/app/actions/tournament-model";
 import { MatchNode } from "@/components/match";
+import { markMatchReturnInvalidate } from "@/hooks/useInvalidateOnMatchReturn";
 import "reactflow/dist/style.css";
 
 const MATCH_WIDTH = 200;
@@ -37,6 +38,7 @@ export default function GraphView({
 
   const router = useRouter();
   const eventId = useParams().id as string;
+  const pathname = usePathname();
 
   useEffect(() => {
     const newNodes: Node[] = [];
@@ -145,6 +147,7 @@ export default function GraphView({
                   (match.state === MatchState.FINISHED || isEventAdmin)
                   && clickedMatch.id
                 ) {
+                  markMatchReturnInvalidate(pathname);
                   router.push(`/events/${eventId}/match/${clickedMatch.id}`);
                 }
               },
@@ -181,6 +184,7 @@ export default function GraphView({
                     || isEventAdmin)
                   && clickedMatch.id
                 ) {
+                  markMatchReturnInvalidate(pathname);
                   router.push(`/events/${eventId}/match/${clickedMatch.id}`);
                 }
               },
@@ -219,7 +223,16 @@ export default function GraphView({
 
     setNodes(newNodes);
     setEdges(newEdges);
-  }, [matches, teamCount, isEventAdmin, router, eventId, setNodes, setEdges]);
+  }, [
+    matches,
+    teamCount,
+    isEventAdmin,
+    router,
+    eventId,
+    pathname,
+    setNodes,
+    setEdges,
+  ]);
 
   return (
     <div className="h-full w-full">

--- a/frontend/app/events/[id]/bracket/page.tsx
+++ b/frontend/app/events/[id]/bracket/page.tsx
@@ -1,12 +1,20 @@
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
 import { isActionError } from "@/app/actions/errors";
 import { isEventAdmin } from "@/app/actions/event";
-import { getTeamsForEventTable } from "@/app/actions/team";
-import {
-  getTournamentMatches,
-  getTournamentTeamCount,
-} from "@/app/actions/tournament";
 import Actions from "@/app/events/[id]/bracket/actions";
 import BracketTabs from "@/app/events/[id]/bracket/BracketTabs";
+import {
+  eventTeamsStandingsQueryFn,
+  eventTeamsStandingsQueryKey,
+  tournamentMatchesQueryFn,
+  tournamentMatchesQueryKey,
+  tournamentTeamCountQueryFn,
+  tournamentTeamCountQueryKey,
+} from "@/app/events/[id]/tournament-queries";
 
 export const metadata = {
   title: "Tournament Bracket",
@@ -26,10 +34,21 @@ export default async function page({
     throw new Error("Failed to verify admin status");
   }
   const isAdminView = (await searchParams).adminReveal === "true";
-  const [serializedMatches, teamCount, teams] = await Promise.all([
-    getTournamentMatches(eventId, isAdminView),
-    getTournamentTeamCount(eventId),
-    getTeamsForEventTable(eventId, undefined, "score", "desc", isAdminView),
+  const queryClient = new QueryClient();
+
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: tournamentMatchesQueryKey(eventId, isAdminView),
+      queryFn: () => tournamentMatchesQueryFn(eventId, isAdminView),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: tournamentTeamCountQueryKey(eventId),
+      queryFn: () => tournamentTeamCountQueryFn(eventId),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: eventTeamsStandingsQueryKey(eventId, isAdminView),
+      queryFn: () => eventTeamsStandingsQueryFn(eventId, isAdminView),
+    }),
   ]);
 
   return (
@@ -51,13 +70,13 @@ export default async function page({
         )}
       </div>
 
-      <BracketTabs
-        eventId={eventId}
-        matches={serializedMatches}
-        teams={teams}
-        isEventAdmin={eventAdmin}
-        teamCount={teamCount}
-      />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <BracketTabs
+          eventId={eventId}
+          isEventAdmin={eventAdmin}
+          adminReveal={isAdminView}
+        />
+      </HydrationBoundary>
     </div>
   );
 }

--- a/frontend/app/events/[id]/groups/GroupPhaseTabs.tsx
+++ b/frontend/app/events/[id]/groups/GroupPhaseTabs.tsx
@@ -1,29 +1,83 @@
 "use client";
 
-import type { Team } from "@/app/actions/team";
-import type { Match } from "@/app/actions/tournament-model";
+import { useQuery } from "@tanstack/react-query";
 import { BarChart3, Network } from "lucide-react";
+import { useMemo } from "react";
+import {
+  eventTeamsStandingsQueryFn,
+  eventTeamsStandingsQueryKey,
+  swissMatchesQueryFn,
+  swissMatchesQueryKey,
+  tournamentTeamCountQueryFn,
+  tournamentTeamCountQueryKey,
+} from "@/app/events/[id]/tournament-queries";
+import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useInvalidateOnMatchReturn } from "@/hooks/useInvalidateOnMatchReturn";
 import { useTabParam } from "@/hooks/useTabParam";
 import GraphView from "./graphView";
 import RankingTable from "./RankingTable";
 
 interface GroupPhaseTabsProps {
   eventId: string;
-  matches: Match[];
-  teams: Team[];
   isEventAdmin: boolean;
-  advancementCount: number;
+  adminReveal: boolean;
 }
 
 export default function GroupPhaseTabs({
   eventId,
-  matches,
-  teams,
   isEventAdmin,
-  advancementCount,
+  adminReveal,
 }: GroupPhaseTabsProps) {
+  const queryKeys = useMemo(
+    () => [
+      swissMatchesQueryKey(eventId, adminReveal),
+      tournamentTeamCountQueryKey(eventId),
+      eventTeamsStandingsQueryKey(eventId, adminReveal),
+    ],
+    [eventId, adminReveal],
+  );
+
+  useInvalidateOnMatchReturn(queryKeys);
   const { currentTab, onTabChange } = useTabParam("graph");
+  const matchesQuery = useQuery({
+    queryKey: swissMatchesQueryKey(eventId, adminReveal),
+    queryFn: () => swissMatchesQueryFn(eventId, adminReveal),
+  });
+  const advancementCountQuery = useQuery({
+    queryKey: tournamentTeamCountQueryKey(eventId),
+    queryFn: () => tournamentTeamCountQueryFn(eventId),
+  });
+  const teamsQuery = useQuery({
+    queryKey: eventTeamsStandingsQueryKey(eventId, adminReveal),
+    queryFn: () => eventTeamsStandingsQueryFn(eventId, adminReveal),
+  });
+
+  const matches = matchesQuery.data;
+  const advancementCount = advancementCountQuery.data;
+  const teams = teamsQuery.data;
+  const isLoading = [matchesQuery, advancementCountQuery, teamsQuery].some(
+    query => query.isPending && query.data === undefined,
+  );
+  const hasError = [matchesQuery, advancementCountQuery, teamsQuery].some(
+    query => query.isError && query.data === undefined,
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[320px] items-center justify-center rounded-xl border bg-card/50">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (hasError || !matches || advancementCount === undefined || !teams) {
+    return (
+      <div className="rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-6 text-sm text-destructive">
+        Failed to load group phase data.
+      </div>
+    );
+  }
 
   return (
     <Tabs value={currentTab} onValueChange={onTabChange} className="w-full">

--- a/frontend/app/events/[id]/groups/graphView.tsx
+++ b/frontend/app/events/[id]/groups/graphView.tsx
@@ -1,11 +1,12 @@
 "use client";
 import type { Node } from "reactflow";
 import type { Match } from "@/app/actions/tournament-model";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import ReactFlow, { Background, useNodesState } from "reactflow";
 import { MatchState } from "@/app/actions/tournament-model";
 import { MatchNode } from "@/components/match";
+import { markMatchReturnInvalidate } from "@/hooks/useInvalidateOnMatchReturn";
 import "reactflow/dist/style.css";
 
 // Custom node types for ReactFlow
@@ -33,10 +34,13 @@ export default function GraphView({
 
   const router = useRouter();
   const eventId = useParams().id as string;
+  const pathname = usePathname();
 
   useEffect(() => {
-    if (!matches || matches.length === 0)
+    if (!matches || matches.length === 0) {
+      setNodes([]);
       return;
+    }
 
     const matchesByRound = matches.reduce(
       (acc, match) => {
@@ -103,6 +107,7 @@ export default function GraphView({
                 (match.state === MatchState.FINISHED || isEventAdmin)
                 && clickedMatch.id
               ) {
+                markMatchReturnInvalidate(pathname);
                 router.push(`/events/${eventId}/match/${clickedMatch.id}`);
               }
             },
@@ -112,7 +117,7 @@ export default function GraphView({
     });
 
     setNodes(newNodes);
-  }, [matches, isEventAdmin, eventId, router]);
+  }, [matches, isEventAdmin, eventId, router, pathname, setNodes]);
 
   return (
     <div className="h-full w-full">

--- a/frontend/app/events/[id]/groups/page.tsx
+++ b/frontend/app/events/[id]/groups/page.tsx
@@ -1,12 +1,20 @@
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
 import { isActionError } from "@/app/actions/errors";
 import { isEventAdmin } from "@/app/actions/event";
-import { getTeamsForEventTable } from "@/app/actions/team";
-import {
-  getSwissMatches,
-  getTournamentTeamCount,
-} from "@/app/actions/tournament";
 import Actions from "@/app/events/[id]/groups/actions";
 import GroupPhaseTabs from "@/app/events/[id]/groups/GroupPhaseTabs";
+import {
+  eventTeamsStandingsQueryFn,
+  eventTeamsStandingsQueryKey,
+  swissMatchesQueryFn,
+  swissMatchesQueryKey,
+  tournamentTeamCountQueryFn,
+  tournamentTeamCountQueryKey,
+} from "@/app/events/[id]/tournament-queries";
 
 export const metadata = {
   title: "Group Phase",
@@ -23,16 +31,28 @@ export default async function page({
 }) {
   const eventId = (await params).id;
   const isAdminView = (await searchParams).adminReveal === "true";
-  const [matches, eventAdmin, teams, advancementCount] = await Promise.all([
-    getSwissMatches(eventId, isAdminView),
-    isEventAdmin(eventId),
-    getTeamsForEventTable(eventId, undefined, "score", "desc", isAdminView),
-    getTournamentTeamCount(eventId),
-  ]);
+  const eventAdmin = await isEventAdmin(eventId);
 
   if (isActionError(eventAdmin)) {
     throw new Error("Failed to verify admin status");
   }
+
+  const queryClient = new QueryClient();
+
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: swissMatchesQueryKey(eventId, isAdminView),
+      queryFn: () => swissMatchesQueryFn(eventId, isAdminView),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: tournamentTeamCountQueryKey(eventId),
+      queryFn: () => tournamentTeamCountQueryFn(eventId),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: eventTeamsStandingsQueryKey(eventId, isAdminView),
+      queryFn: () => eventTeamsStandingsQueryFn(eventId, isAdminView),
+    }),
+  ]);
 
   return (
     <div className="flex flex-col gap-4 pb-8 md:gap-8">
@@ -53,13 +73,13 @@ export default async function page({
         )}
       </div>
 
-      <GroupPhaseTabs
-        eventId={eventId}
-        matches={matches}
-        teams={teams}
-        isEventAdmin={eventAdmin}
-        advancementCount={advancementCount}
-      />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <GroupPhaseTabs
+          eventId={eventId}
+          isEventAdmin={eventAdmin}
+          adminReveal={isAdminView}
+        />
+      </HydrationBoundary>
     </div>
   );
 }

--- a/frontend/app/events/[id]/tournament-queries.ts
+++ b/frontend/app/events/[id]/tournament-queries.ts
@@ -1,0 +1,105 @@
+import type { Team } from "@/app/actions/team";
+import type { Match } from "@/app/actions/tournament-model";
+import axiosInstance from "@/app/actions/axios";
+
+interface EventTeamResponse {
+  id: string;
+  name: string;
+  repo?: string | null;
+  userCount?: number;
+  score?: number | null;
+  buchholzPoints?: number | null;
+  hadBye?: boolean | null;
+  queueScore?: number | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+function withAdminReveal(adminReveal: boolean) {
+  return adminReveal ? { adminRevealQuery: true } : {};
+}
+
+function mapEventTeam(team: EventTeamResponse): Team {
+  return {
+    id: team.id,
+    name: team.name,
+    repo: team.repo || "",
+    inQueue: false,
+    membersCount: team.userCount,
+    score: team.score ?? 0,
+    buchholzPoints: team.buchholzPoints ?? 0,
+    hadBye: team.hadBye ?? false,
+    queueScore: team.queueScore ?? 0,
+    createdAt: team.createdAt,
+    updatedAt: team.updatedAt,
+  };
+}
+
+export function tournamentMatchesQueryKey(
+  eventId: string,
+  adminReveal: boolean,
+) {
+  return ["event", eventId, "tournament-matches", adminReveal] as const;
+}
+
+export async function tournamentMatchesQueryFn(
+  eventId: string,
+  adminReveal: boolean,
+): Promise<Match[]> {
+  const response = await axiosInstance.get<Match[]>(`/match/tournament/${eventId}`, {
+    params: withAdminReveal(adminReveal),
+  });
+  return response.data;
+}
+
+export function swissMatchesQueryKey(eventId: string, adminReveal: boolean) {
+  return ["event", eventId, "swiss-matches", adminReveal] as const;
+}
+
+export async function swissMatchesQueryFn(
+  eventId: string,
+  adminReveal: boolean,
+): Promise<Match[]> {
+  const response = await axiosInstance.get<Match[]>(`/match/swiss/${eventId}`, {
+    params: withAdminReveal(adminReveal),
+  });
+  return response.data;
+}
+
+export function eventTeamsStandingsQueryKey(
+  eventId: string,
+  adminReveal: boolean,
+) {
+  return ["event", eventId, "teams-standings", adminReveal] as const;
+}
+
+export async function eventTeamsStandingsQueryFn(
+  eventId: string,
+  adminReveal: boolean,
+): Promise<Team[]> {
+  const response = await axiosInstance.get<EventTeamResponse[]>(
+    `team/event/${eventId}/`,
+    {
+      params: {
+        sortBy: "score",
+        sortDir: "desc",
+        ...withAdminReveal(adminReveal),
+      },
+    },
+  );
+
+  return response.data.map(mapEventTeam);
+}
+
+export function tournamentTeamCountQueryKey(eventId: string) {
+  return ["event", eventId, "tournament-team-count"] as const;
+}
+
+export async function tournamentTeamCountQueryFn(
+  eventId: string,
+): Promise<number> {
+  const response = await axiosInstance.get<number>(
+    `/match/tournament/${eventId}/teamCount`,
+  );
+  return response.data;
+}

--- a/frontend/components/match/MatchHistoryBadges.tsx
+++ b/frontend/components/match/MatchHistoryBadges.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { markMatchReturnInvalidate } from "@/hooks/useInvalidateOnMatchReturn";
 import { cn } from "@/lib/utils";
 
 interface MatchResult {
@@ -18,6 +19,7 @@ export function MatchHistoryBadges({
   eventId,
 }: MatchHistoryBadgesProps) {
   const router = useRouter();
+  const pathname = usePathname();
 
   if (history.length === 0) {
     return <span className="text-xs text-muted-foreground">No matches</span>;
@@ -30,6 +32,7 @@ export function MatchHistoryBadges({
           key={i}
           onClick={(e) => {
             e.stopPropagation();
+            markMatchReturnInvalidate(pathname);
             router.push(`/events/${eventId}/match/${match.id}`);
           }}
           className={cn(

--- a/frontend/hooks/useInvalidateOnMatchReturn.ts
+++ b/frontend/hooks/useInvalidateOnMatchReturn.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+const INVALIDATE_ON_MATCH_RETURN_KEY = "invalidate-on-match-return";
+
+export function markMatchReturnInvalidate(pathname: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.sessionStorage.setItem(INVALIDATE_ON_MATCH_RETURN_KEY, pathname);
+}
+
+export function useInvalidateOnMatchReturn(
+  queryKeys: readonly (readonly unknown[])[],
+) {
+  const pathname = usePathname();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const invalidatePath = window.sessionStorage.getItem(
+      INVALIDATE_ON_MATCH_RETURN_KEY,
+    );
+
+    if (invalidatePath !== pathname) {
+      return;
+    }
+
+    window.sessionStorage.removeItem(INVALIDATE_ON_MATCH_RETURN_KEY);
+    queryKeys.forEach((queryKey) => {
+      void queryClient.invalidateQueries({ queryKey });
+    });
+  }, [pathname, queryClient, queryKeys]);
+}


### PR DESCRIPTION
Move tournament pages to React Query with server prefetching, invalidate cached queries on match navigation return, and add api/.dockerignore to trim Docker build context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced caching and data loading for tournament bracket and group phase displays for improved responsiveness.
  * Optimized match history navigation with better cache management when returning to tournament matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->