### PR TITLE
feat: added dynamic visualizer versions

### DIFF
--- a/frontend/src/lib/visualizer-url.test.ts
+++ b/frontend/src/lib/visualizer-url.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildMatchVisualizerUrl,
+  extractVisualizerTag,
+  normalizeVisualizerTag,
+} from './visualizer-url'
+
+describe('extractVisualizerTag', () => {
+  it('extracts a tag after the image name', () => {
+    expect(
+      extractVisualizerTag('ghcr.io/42core-team/visualizer:1.2.3'),
+    ).toBe('1.2.3')
+  })
+
+  it('ignores a registry port', () => {
+    expect(
+      extractVisualizerTag('registry.example:5000/visualizer:1.2.3'),
+    ).toBe('1.2.3')
+    expect(extractVisualizerTag('registry.example:5000/visualizer')).toBe(
+      undefined,
+    )
+  })
+
+  it('returns no tag for an untagged image', () => {
+    expect(extractVisualizerTag('ghcr.io/42core-team/visualizer')).toBe(
+      undefined,
+    )
+  })
+})
+
+describe('normalizeVisualizerTag', () => {
+  it.each([
+    ['1.2.3.4', '1.2.3'],
+    ['1.2.3.4.5', '1.2.3'],
+    ['v1.2.3.4', 'v1.2.3'],
+    ['v1.2.3', 'v1.2.3'],
+    ['1.2.3', '1.2.3'],
+    ['1.2', '1.2'],
+    ['latest', 'latest'],
+    ['release-candidate', 'release-candidate'],
+  ])('normalizes %s to %s', (tag, expected) => {
+    expect(normalizeVisualizerTag(tag)).toBe(expected)
+  })
+})
+
+describe('buildMatchVisualizerUrl', () => {
+  const defaults = {
+    visualizerUrl: 'https://visualizer.example',
+    replaysBucketUrl: 'https://replays.example',
+    matchId: 'match-id',
+  }
+
+  it('adds the normalized image tag as a path segment', () => {
+    const result = buildMatchVisualizerUrl({
+      ...defaults,
+      visualizerDockerImage: 'ghcr.io/core/visualizer:v1.2.3.4',
+    })
+    const url = new URL(result!)
+
+    expect(url.pathname).toBe('/v1.2.3')
+  })
+
+  it('preserves an existing path and query parameters', () => {
+    const result = buildMatchVisualizerUrl({
+      ...defaults,
+      visualizerUrl: 'https://visualizer.example/embed/?existing=value',
+      visualizerDockerImage: 'visualizer:release candidate',
+      phase: 'SWISS',
+      round: 0,
+    })
+    const url = new URL(result!)
+
+    expect(url.pathname).toBe('/embed/release%20candidate')
+    expect(url.searchParams.get('existing')).toBe('value')
+    expect(url.searchParams.get('replays')).toBe(
+      'https://replays.example/match-id/replay.json',
+    )
+    expect(url.searchParams.get('dynamicSpeed')).toBe('on')
+    expect(url.searchParams.get('autoplay')).toBe('start')
+    expect(url.searchParams.get('mode')).toBe('SWISS')
+    expect(url.searchParams.get('round')).toBe('0')
+  })
+
+  it('uses the unversioned path when the image has no tag', () => {
+    const result = buildMatchVisualizerUrl({
+      ...defaults,
+      visualizerUrl: 'https://visualizer.example/embed/',
+      visualizerDockerImage: 'ghcr.io/core/visualizer',
+    })
+
+    expect(new URL(result!).pathname).toBe('/embed/')
+  })
+
+  it('returns null when a required base URL is missing', () => {
+    expect(
+      buildMatchVisualizerUrl({ ...defaults, visualizerUrl: '' }),
+    ).toBeNull()
+    expect(
+      buildMatchVisualizerUrl({ ...defaults, replaysBucketUrl: '' }),
+    ).toBeNull()
+  })
+})

--- a/frontend/src/lib/visualizer-url.ts
+++ b/frontend/src/lib/visualizer-url.ts
@@ -1,0 +1,59 @@
+export interface MatchVisualizerUrlOptions {
+  visualizerUrl: string
+  replaysBucketUrl: string
+  matchId: string
+  visualizerDockerImage?: string
+  phase?: string
+  round?: number
+}
+
+export function extractVisualizerTag(
+  visualizerDockerImage?: string,
+): string | undefined {
+  if (!visualizerDockerImage) return undefined
+
+  const lastSlashIndex = visualizerDockerImage.lastIndexOf('/')
+  const lastColonIndex = visualizerDockerImage.lastIndexOf(':')
+
+  if (lastColonIndex <= lastSlashIndex) return undefined
+
+  const tag = visualizerDockerImage.slice(lastColonIndex + 1)
+  return tag || undefined
+}
+
+export function normalizeVisualizerTag(tag: string): string {
+  if (!/^v?\d+(?:\.\d+)+$/.test(tag)) return tag
+
+  const prefix = tag.startsWith('v') ? 'v' : ''
+  const versionParts = tag.slice(prefix.length).split('.')
+
+  return `${prefix}${versionParts.slice(0, 3).join('.')}`
+}
+
+export function buildMatchVisualizerUrl({
+  visualizerUrl,
+  replaysBucketUrl,
+  matchId,
+  visualizerDockerImage,
+  phase,
+  round,
+}: MatchVisualizerUrlOptions): string | null {
+  if (!visualizerUrl || !replaysBucketUrl) return null
+
+  const url = new URL(visualizerUrl)
+  const visualizerTag = extractVisualizerTag(visualizerDockerImage)
+
+  if (visualizerTag) {
+    const normalizedTag = normalizeVisualizerTag(visualizerTag)
+    const basePath = url.pathname.replace(/\/$/, '')
+    url.pathname = `${basePath}/${encodeURIComponent(normalizedTag)}`
+  }
+
+  url.searchParams.set('replays', `${replaysBucketUrl}/${matchId}/replay.json`)
+  url.searchParams.set('dynamicSpeed', 'on')
+  url.searchParams.set('autoplay', 'start')
+  if (phase) url.searchParams.set('mode', phase)
+  if (typeof round === 'number') url.searchParams.set('round', String(round))
+
+  return url.toString()
+}

--- a/frontend/src/routes/events/$id/match/$matchId.tsx
+++ b/frontend/src/routes/events/$id/match/$matchId.tsx
@@ -1,29 +1,36 @@
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { ExternalLink } from 'lucide-react'
+import { getEventById } from '@/app/actions/event'
 import { getLogsOfMatch, getMatchById } from '@/app/actions/tournament'
 import MatchLogsDisplay from '@/components/match/MatchLogsDisplay'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
 import { getS3ReplaysBucketUrl, getVisualizerUrl } from '@/lib/env'
+import { buildMatchVisualizerUrl } from '@/lib/visualizer-url'
 
 export const Route = createFileRoute('/events/$id/match/$matchId')({
   component: MatchRoute,
 })
 
 function MatchRoute() {
-  const { matchId } = Route.useParams()
+  const { id, matchId } = Route.useParams()
   const matchQuery = useQuery({
     queryKey: ['match', matchId],
     queryFn: async () => getMatchById(matchId),
   })
-  const visualizerUrl = matchQuery.data
-    ? getMatchVisualizerUrl(
-        matchId,
-        matchQuery.data.phase,
-        matchQuery.data.round,
-      )
-    : getMatchVisualizerUrl(matchId)
+  const eventQuery = useQuery({
+    queryKey: ['event', id],
+    queryFn: async () => getEventById(id),
+  })
+  const visualizerUrl = buildMatchVisualizerUrl({
+    visualizerUrl: getVisualizerUrl(),
+    replaysBucketUrl: getS3ReplaysBucketUrl(),
+    matchId,
+    visualizerDockerImage: eventQuery.data?.visualizerDockerImage,
+    phase: matchQuery.data?.phase,
+    round: matchQuery.data?.round,
+  })
   const logsQuery = useQuery({
     queryKey: ['match', matchId, 'logs'],
     queryFn: async () => getLogsOfMatch(matchId),
@@ -74,24 +81,4 @@ function MatchRoute() {
       </div>
     </main>
   )
-}
-
-function getMatchVisualizerUrl(
-  matchId: string,
-  phase?: string,
-  round?: number,
-) {
-  const visualizerUrl = getVisualizerUrl()
-  const replaysBucketUrl = getS3ReplaysBucketUrl()
-
-  if (!visualizerUrl || !replaysBucketUrl) return null
-
-  const url = new URL(visualizerUrl)
-  url.searchParams.set('replays', `${replaysBucketUrl}/${matchId}/replay.json`)
-  url.searchParams.set('dynamicSpeed', 'on')
-  url.searchParams.set('autoplay', 'start')
-  if (phase) url.searchParams.set('mode', phase)
-  if (typeof round === 'number') url.searchParams.set('round', String(round))
-
-  return url.toString()
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added match visualizer URL generation with support for versioned visualizer deployments.
  * Visualizer links now include replay data, playback settings, match phase, and round details.
  * Existing visualizer paths and query parameters are preserved when generating links.
  * Matches without a visualizer version use the standard visualizer path.

* **Bug Fixes**
  * Visualizer links are not generated when required configuration is unavailable.

* **Tests**
  * Added coverage for image tag extraction, version normalization, and visualizer URL construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->