### PR TITLE
feat(event): restrict event join to piscine/42cursus audience

### DIFF
--- a/api/db/migrations/1784375696042-socialAccountCursusFlags.ts
+++ b/api/db/migrations/1784375696042-socialAccountCursusFlags.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class SocialAccountCursusFlags1784375696042 implements MigrationInterface {
+    name = 'SocialAccountCursusFlags1784375696042'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "social_accounts" ADD "isPiscineStudent" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "social_accounts" ADD "isCursusStudent" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "social_accounts" DROP COLUMN "isCursusStudent"`);
+        await queryRunner.query(`ALTER TABLE "social_accounts" DROP COLUMN "isPiscineStudent"`);
+    }
+
+}

--- a/api/db/migrations/1784375696042-socialAccountCursusFlags.ts
+++ b/api/db/migrations/1784375696042-socialAccountCursusFlags.ts
@@ -4,13 +4,11 @@ export class SocialAccountCursusFlags1784375696042 implements MigrationInterface
     name = 'SocialAccountCursusFlags1784375696042'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "social_accounts" ADD "isPiscineStudent" boolean NOT NULL DEFAULT false`);
-        await queryRunner.query(`ALTER TABLE "social_accounts" ADD "isCursusStudent" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "social_accounts" ADD "cursusStatus" text NOT NULL DEFAULT 'NONE'`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "social_accounts" DROP COLUMN "isCursusStudent"`);
-        await queryRunner.query(`ALTER TABLE "social_accounts" DROP COLUMN "isPiscineStudent"`);
+        await queryRunner.query(`ALTER TABLE "social_accounts" DROP COLUMN "cursusStatus"`);
     }
 
 }

--- a/api/db/migrations/1784375696043-eventAudience.ts
+++ b/api/db/migrations/1784375696043-eventAudience.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class EventAudience1784375696043 implements MigrationInterface {
+    name = 'EventAudience1784375696043'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "events" ADD "audience" text NOT NULL DEFAULT 'BOTH'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "events" DROP COLUMN "audience"`);
+    }
+
+}

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -21,7 +21,10 @@ import { UserService } from "../user/user.service";
 import { UserId } from "../guards/UserGuard";
 import * as CryptoJS from "crypto-js";
 import { SocialAccountService } from "../user/social-account.service";
-import { SocialPlatform } from "../user/entities/social-account.entity";
+import {
+  FortyTwoCursusStatus,
+  SocialPlatform,
+} from "../user/entities/social-account.entity";
 
 @Controller("auth")
 export class AuthController {
@@ -70,8 +73,7 @@ export class AuthController {
           platformUserId: string;
           username: string;
           email: string;
-          isPiscineStudent: boolean;
-          isCursusStudent: boolean;
+          cursusStatus: FortyTwoCursusStatus;
           campusId: number | null;
           campusName: string | null;
         };
@@ -97,8 +99,7 @@ export class AuthController {
         platform: SocialPlatform.FORTYTWO,
         platformUserId: request.user.fortyTwoAccount.platformUserId,
         username: request.user.fortyTwoAccount.username,
-        isPiscineStudent: request.user.fortyTwoAccount.isPiscineStudent,
-        isCursusStudent: request.user.fortyTwoAccount.isCursusStudent,
+        cursusStatus: request.user.fortyTwoAccount.cursusStatus,
         campusId: request.user.fortyTwoAccount.campusId,
         campusName: request.user.fortyTwoAccount.campusName,
       });

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -70,6 +70,8 @@ export class AuthController {
           platformUserId: string;
           username: string;
           email: string;
+          isPiscineStudent: boolean;
+          isCursusStudent: boolean;
         };
       };
     },
@@ -93,6 +95,8 @@ export class AuthController {
         platform: SocialPlatform.FORTYTWO,
         platformUserId: request.user.fortyTwoAccount.platformUserId,
         username: request.user.fortyTwoAccount.username,
+        isPiscineStudent: request.user.fortyTwoAccount.isPiscineStudent,
+        isCursusStudent: request.user.fortyTwoAccount.isCursusStudent,
       });
 
       this.logger.log({ action: "fortytwo_link", userId });

--- a/api/src/auth/fortytwo.strategy.ts
+++ b/api/src/auth/fortytwo.strategy.ts
@@ -12,6 +12,7 @@ export interface FortyTwoProfile {
   cursus_users?: { cursus?: { slug?: string } }[];
   campus?: Array<{ id: number; name: string }>;
   campus_users?: Array<{ campus_id: number; is_primary: boolean }>;
+}
 
 export function getPrimaryCampus(profile: FortyTwoProfile): {
   campusId: number | null;
@@ -82,8 +83,6 @@ export class FortyTwoOAuthStrategy extends PassportStrategy(Strategy, "42") {
           isCursusStudent,
           isPiscineStudent,
           ...primaryCampus,
-          isCursusStudent,
-          isPiscineStudent,
         },
       });
     } catch (err) {

--- a/api/src/auth/fortytwo.strategy.ts
+++ b/api/src/auth/fortytwo.strategy.ts
@@ -11,6 +11,7 @@ interface FortyTwoProfile {
   email: string | null;
   image_url: string | null;
   displayname: string | null;
+  cursus_users?: { cursus?: { slug?: string } }[];
 }
 
 @Injectable()
@@ -50,11 +51,24 @@ export class FortyTwoOAuthStrategy extends PassportStrategy(Strategy, "42") {
       const username = data.login;
       const email = data.email ?? undefined;
 
+      // 42 intra has no single "role" field; membership is derived from the
+      // cursus slugs returned on the user's profile.
+      const cursusSlugs = (data.cursus_users ?? [])
+        .map((cu) => cu.cursus?.slug)
+        .filter((slug): slug is string => !!slug);
+      const isCursusStudent = cursusSlugs.includes("42cursus");
+      // 42 never removes the old piscine cursus_user record once a student
+      // progresses to 42cursus, so "piscine student" must exclude cursus students.
+      const isPiscineStudent =
+        cursusSlugs.includes("c-piscine") && !isCursusStudent;
+
       done(null, {
         fortyTwoAccount: {
           platformUserId,
           username,
           email,
+          isCursusStudent,
+          isPiscineStudent,
         },
       });
     } catch (err) {

--- a/api/src/auth/fortytwo.strategy.ts
+++ b/api/src/auth/fortytwo.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { ConfigService } from "@nestjs/config";
 import { Strategy } from "passport-oauth2";
+import { FortyTwoCursusStatus } from "../user/entities/social-account.entity";
 
 export interface FortyTwoProfile {
   id: number;
@@ -69,19 +70,20 @@ export class FortyTwoOAuthStrategy extends PassportStrategy(Strategy, "42") {
       const cursusSlugs = (data.cursus_users ?? [])
         .map((cu) => cu.cursus?.slug)
         .filter((slug): slug is string => !!slug);
-      const isCursusStudent = cursusSlugs.includes("42cursus");
       // 42 never removes the old piscine cursus_user record once a student
-      // progresses to 42cursus, so "piscine student" must exclude cursus students.
-      const isPiscineStudent =
-        cursusSlugs.includes("c-piscine") && !isCursusStudent;
+      // progresses to 42cursus, so cursus status wins over piscine history.
+      const cursusStatus = cursusSlugs.includes("42cursus")
+        ? FortyTwoCursusStatus.CURSUS
+        : cursusSlugs.includes("c-piscine")
+          ? FortyTwoCursusStatus.PISCINE
+          : FortyTwoCursusStatus.NONE;
 
       done(null, {
         fortyTwoAccount: {
           platformUserId,
           username,
           email,
-          isCursusStudent,
-          isPiscineStudent,
+          cursusStatus,
           ...primaryCampus,
         },
       });

--- a/api/src/event/dtos/createEventDto.ts
+++ b/api/src/event/dtos/createEventDto.ts
@@ -6,8 +6,10 @@ import {
   Min,
   IsNotEmpty,
   IsBoolean,
+  IsEnum,
 } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
+import { EventAudience } from "../entities/event.entity";
 
 export class CreateEventDto {
   @ApiProperty()
@@ -88,4 +90,9 @@ export class CreateEventDto {
   @ApiProperty()
   @IsBoolean()
   isPrivate: boolean;
+
+  @ApiProperty({ enum: EventAudience })
+  @IsOptional()
+  @IsEnum(EventAudience)
+  audience?: EventAudience;
 }

--- a/api/src/event/dtos/updateEventSettingsDto.ts
+++ b/api/src/event/dtos/updateEventSettingsDto.ts
@@ -1,5 +1,12 @@
 import { ApiPropertyOptional } from "@nestjs/swagger";
-import { IsBoolean, IsNumber, IsOptional, IsString } from "class-validator";
+import {
+  IsBoolean,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from "class-validator";
+import { EventAudience } from "../entities/event.entity";
 
 export class UpdateEventSettingsDto {
   @ApiPropertyOptional()
@@ -16,6 +23,11 @@ export class UpdateEventSettingsDto {
   @IsOptional()
   @IsBoolean()
   isPrivate?: boolean;
+
+  @ApiPropertyOptional({ enum: EventAudience })
+  @IsOptional()
+  @IsEnum(EventAudience)
+  audience?: EventAudience;
 
   @ApiPropertyOptional()
   @IsOptional()

--- a/api/src/event/entities/event.entity.ts
+++ b/api/src/event/entities/event.entity.ts
@@ -17,6 +17,12 @@ import { Exclude } from "class-transformer";
 import { EventStarterTemplateEntity } from "./event-starter-template.entity";
 import { EventWhitelistEntity } from "./event-whitelist.entity";
 
+export enum EventAudience {
+  PISCINE = "PISCINE",
+  CURSUS = "CURSUS",
+  BOTH = "BOTH",
+}
+
 @Entity("events")
 export class EventEntity {
   @PrimaryGeneratedColumn("uuid")
@@ -97,6 +103,9 @@ export class EventEntity {
 
   @Column({ default: false })
   isPrivate: boolean;
+
+  @Column({ type: "text", default: EventAudience.BOTH })
+  audience: EventAudience;
 
   @JoinTable({ name: "events_users" })
   @ManyToMany(() => UserEntity, (user) => user.events, {

--- a/api/src/event/event.controller.ts
+++ b/api/src/event/event.controller.ts
@@ -24,6 +24,7 @@ import { AddToWhitelistDto, BulkDeleteWhitelistDto } from "./dtos/whitelistDto";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
 import { UserId } from "../guards/UserGuard";
 import { SocialPlatform } from "src/user/entities/social-account.entity";
+import { EventAudience } from "./entities/event.entity";
 
 @Controller("event")
 export class EventController {
@@ -122,6 +123,7 @@ export class EventController {
       createEventDto.gameConfig,
       createEventDto.serverConfig,
       createEventDto.isPrivate,
+      createEventDto.audience,
     );
   }
 
@@ -173,13 +175,33 @@ export class EventController {
 
     const event = await this.eventService.getEventById(eventId);
 
-    if (event.isPrivate) {
-      const user = await this.userService.getUserWithSocialAccounts(userId);
-      const socialAccounts = user.socialAccounts || [];
-      const fortyTwoAccount = socialAccounts.find(
-        (sa) => sa.platform === SocialPlatform.FORTYTWO,
-      );
+    const user = await this.userService.getUserWithSocialAccounts(userId);
+    const socialAccounts = user.socialAccounts || [];
+    const fortyTwoAccount = socialAccounts.find(
+      (sa) => sa.platform === SocialPlatform.FORTYTWO,
+    );
 
+    if (event.audience !== EventAudience.BOTH) {
+      if (!fortyTwoAccount) {
+        throw new UnauthorizedException(
+          "You must link your 42 intra account to join this event.",
+        );
+      }
+
+      const isEligible = await this.eventService.isUserEligibleForEventAudience(
+        event.audience,
+        userId,
+      );
+      if (!isEligible) {
+        throw new UnauthorizedException(
+          event.audience === EventAudience.PISCINE
+            ? "This event is only open to piscine students."
+            : "This event is only open to 42cursus students.",
+        );
+      }
+    }
+
+    if (event.isPrivate) {
       const isWhitelisted = await this.eventService.isUserWhitelisted(
         eventId,
         user.username,

--- a/api/src/event/event.service.ts
+++ b/api/src/event/event.service.ts
@@ -8,7 +8,7 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { EventEntity } from "./entities/event.entity";
+import { EventAudience, EventEntity } from "./entities/event.entity";
 import { EventStarterTemplateEntity } from "./entities/event-starter-template.entity";
 import { EventWhitelistEntity } from "./entities/event-whitelist.entity";
 import {
@@ -32,6 +32,8 @@ import { Cron, CronExpression } from "@nestjs/schedule";
 import { EventVersionDto } from "./dtos/eventVersionDto";
 import { LockKeys } from "../constants";
 import { WhitelistPlatform } from "./entities/event-whitelist.entity";
+import { SocialAccountService } from "../user/social-account.service";
+import { SocialPlatform } from "../user/entities/social-account.entity";
 
 @Injectable()
 export class EventService {
@@ -48,6 +50,7 @@ export class EventService {
     @Inject(forwardRef(() => TeamService))
     private readonly teamService: TeamService,
     private readonly dataSource: DataSource,
+    private readonly socialAccountService: SocialAccountService,
   ) {}
 
   logger = new Logger("EventService");
@@ -271,6 +274,7 @@ export class EventService {
     gameConfig: string,
     serverConfig: string,
     isPrivate: boolean = false,
+    audience: EventAudience = EventAudience.BOTH,
   ) {
     githubOrgSecret = CryptoJS.AES.encrypt(
       githubOrgSecret,
@@ -309,6 +313,7 @@ export class EventService {
       gameConfig,
       serverConfig,
       isPrivate,
+      audience,
     });
   }
 
@@ -388,11 +393,36 @@ export class EventService {
     });
   }
 
+  async isUserEligibleForEventAudience(
+    audience: EventAudience,
+    userId: string,
+  ): Promise<boolean> {
+    if (audience === EventAudience.BOTH) return true;
+
+    const fortyTwoAccount =
+      await this.socialAccountService.getSocialAccountByPlatform(
+        userId,
+        SocialPlatform.FORTYTWO,
+      );
+    if (!fortyTwoAccount) return false;
+
+    if (audience === EventAudience.PISCINE)
+      return fortyTwoAccount.isPiscineStudent;
+    return fortyTwoAccount.isCursusStudent;
+  }
+
   async isUserRegisteredForEvent(eventId: string, userId: string) {
+    const event = await this.eventRepository.findOneOrFail({
+      where: { id: eventId },
+    });
+
+    if (!(await this.isUserEligibleForEventAudience(event.audience, userId)))
+      return false;
+
     /**
-     * for public events, all users are considered registered
+     * for public events, all eligible users are considered registered
      */
-    if (await this.isEventPublic(eventId)) return true;
+    if (!event.isPrivate) return true;
     return await this.eventRepository.existsBy({
       id: eventId,
       users: {
@@ -474,6 +504,7 @@ export class EventService {
       canCreateTeam?: boolean;
       processQueue?: boolean;
       isPrivate?: boolean;
+      audience?: EventAudience;
       name?: string;
       description?: string;
       githubOrg?: string;
@@ -526,6 +557,10 @@ export class EventService {
       if (typeof settings[field] === "string") {
         update[field] = settings[field];
       }
+    }
+
+    if (settings.audience) {
+      update.audience = settings.audience;
     }
 
     if (settings.githubOrgSecret) {

--- a/api/src/event/event.service.ts
+++ b/api/src/event/event.service.ts
@@ -33,7 +33,10 @@ import { EventVersionDto } from "./dtos/eventVersionDto";
 import { LockKeys } from "../constants";
 import { WhitelistPlatform } from "./entities/event-whitelist.entity";
 import { SocialAccountService } from "../user/social-account.service";
-import { SocialPlatform } from "../user/entities/social-account.entity";
+import {
+  FortyTwoCursusStatus,
+  SocialPlatform,
+} from "../user/entities/social-account.entity";
 
 @Injectable()
 export class EventService {
@@ -407,8 +410,8 @@ export class EventService {
     if (!fortyTwoAccount) return false;
 
     if (audience === EventAudience.PISCINE)
-      return fortyTwoAccount.isPiscineStudent;
-    return fortyTwoAccount.isCursusStudent;
+      return fortyTwoAccount.cursusStatus === FortyTwoCursusStatus.PISCINE;
+    return fortyTwoAccount.cursusStatus === FortyTwoCursusStatus.CURSUS;
   }
 
   async isUserRegisteredForEvent(eventId: string, userId: string) {

--- a/api/src/user/entities/social-account.entity.ts
+++ b/api/src/user/entities/social-account.entity.ts
@@ -13,6 +13,12 @@ export enum SocialPlatform {
   FORTYTWO = "42",
 }
 
+export enum FortyTwoCursusStatus {
+  NONE = "NONE",
+  PISCINE = "PISCINE",
+  CURSUS = "CURSUS",
+}
+
 export const SOCIAL_ACCOUNT_PLATFORM_USER_ID_UNIQUE_CONSTRAINT =
   "UQ_social_accounts_platform_platform_user_id";
 
@@ -44,11 +50,8 @@ export class SocialAccountEntity {
   @Column()
   userId: string; // Reference to our user
 
-  @Column({ default: false })
-  isPiscineStudent: boolean; // 42 intra: enrolled in a piscine cursus
-
-  @Column({ default: false })
-  isCursusStudent: boolean; // 42 intra: enrolled in the 42cursus
+  @Column({ type: "text", default: FortyTwoCursusStatus.NONE })
+  cursusStatus: FortyTwoCursusStatus;
 
   @ManyToOne(() => UserEntity, (user) => user.socialAccounts, {
     onDelete: "CASCADE",

--- a/api/src/user/entities/social-account.entity.ts
+++ b/api/src/user/entities/social-account.entity.ts
@@ -38,6 +38,12 @@ export class SocialAccountEntity {
   @Column()
   userId: string; // Reference to our user
 
+  @Column({ default: false })
+  isPiscineStudent: boolean; // 42 intra: enrolled in a piscine cursus
+
+  @Column({ default: false })
+  isCursusStudent: boolean; // 42 intra: enrolled in the 42cursus
+
   @ManyToOne(() => UserEntity, (user) => user.socialAccounts, {
     onDelete: "CASCADE",
   })

--- a/api/src/user/social-account.service.ts
+++ b/api/src/user/social-account.service.ts
@@ -98,8 +98,6 @@ export class SocialAccountService {
       isCursusStudent: params.isCursusStudent ?? false,
       campusId: params.campusId,
       campusName: params.campusName,
-      isPiscineStudent: params.isPiscineStudent ?? false,
-      isCursusStudent: params.isCursusStudent ?? false,
     });
     return this.saveSocialAccount(entity);
   }

--- a/api/src/user/social-account.service.ts
+++ b/api/src/user/social-account.service.ts
@@ -57,6 +57,8 @@ export class SocialAccountService {
     platform: SocialPlatform;
     username: string;
     platformUserId: string;
+    isPiscineStudent?: boolean;
+    isCursusStudent?: boolean;
   }): Promise<SocialAccountEntity> {
     const linkedAccount = await this.socialAccountRepository.findOne({
       where: {
@@ -76,6 +78,10 @@ export class SocialAccountService {
     if (existing) {
       existing.username = params.username;
       existing.platformUserId = params.platformUserId;
+      if (params.isPiscineStudent !== undefined)
+        existing.isPiscineStudent = params.isPiscineStudent;
+      if (params.isCursusStudent !== undefined)
+        existing.isCursusStudent = params.isCursusStudent;
       return this.saveSocialAccount(existing);
     }
 
@@ -84,6 +90,8 @@ export class SocialAccountService {
       platform: params.platform,
       username: params.username,
       platformUserId: params.platformUserId,
+      isPiscineStudent: params.isPiscineStudent ?? false,
+      isCursusStudent: params.isCursusStudent ?? false,
     });
     return this.saveSocialAccount(entity);
   }

--- a/api/src/user/social-account.service.ts
+++ b/api/src/user/social-account.service.ts
@@ -6,6 +6,7 @@ import {
 import { InjectRepository } from "@nestjs/typeorm";
 import { QueryFailedError, Repository } from "typeorm";
 import {
+  FortyTwoCursusStatus,
   SocialAccountEntity,
   SOCIAL_ACCOUNT_PLATFORM_USER_ID_UNIQUE_CONSTRAINT,
   SocialPlatform,
@@ -57,8 +58,7 @@ export class SocialAccountService {
     platform: SocialPlatform;
     username: string;
     platformUserId: string;
-    isPiscineStudent?: boolean;
-    isCursusStudent?: boolean;
+    cursusStatus?: FortyTwoCursusStatus;
     campusId: number | null;
     campusName: string | null;
   }): Promise<SocialAccountEntity> {
@@ -80,10 +80,8 @@ export class SocialAccountService {
     if (existing) {
       existing.username = params.username;
       existing.platformUserId = params.platformUserId;
-      if (params.isPiscineStudent !== undefined)
-        existing.isPiscineStudent = params.isPiscineStudent;
-      if (params.isCursusStudent !== undefined)
-        existing.isCursusStudent = params.isCursusStudent;
+      if (params.cursusStatus !== undefined)
+        existing.cursusStatus = params.cursusStatus;
       existing.campusId = params.campusId;
       existing.campusName = params.campusName;
       return this.saveSocialAccount(existing);
@@ -94,8 +92,7 @@ export class SocialAccountService {
       platform: params.platform,
       username: params.username,
       platformUserId: params.platformUserId,
-      isPiscineStudent: params.isPiscineStudent ?? false,
-      isCursusStudent: params.isCursusStudent ?? false,
+      cursusStatus: params.cursusStatus ?? FortyTwoCursusStatus.NONE,
       campusId: params.campusId,
       campusName: params.campusName,
     });

--- a/frontend/src/app/actions/event.ts
+++ b/frontend/src/app/actions/event.ts
@@ -1,3 +1,4 @@
+import type { EventAudience } from '@/lib/constants/event-audience'
 import type { WhitelistPlatform } from '@/lib/constants/whitelist'
 
 import axiosInstance from '@/app/actions/axios'
@@ -28,6 +29,7 @@ export interface Event {
   gameConfig?: string
   serverConfig?: string
   isPrivate: boolean
+  audience: EventAudience
   githubOrgSecret?: string
   starterTemplates?: EventStarterTemplate[]
 }
@@ -106,6 +108,7 @@ export interface EventCreateParams {
   gameConfig: string
   serverConfig: string
   isPrivate: boolean
+  audience: EventAudience
 }
 
 // Create a new event

--- a/frontend/src/app/actions/social-accounts.ts
+++ b/frontend/src/app/actions/social-accounts.ts
@@ -1,3 +1,4 @@
+import type { FortyTwoCursusStatus } from '@/lib/constants/cursus-status'
 import axiosInstance from './axios'
 
 export interface SocialAccount {
@@ -6,8 +7,7 @@ export interface SocialAccount {
   username: string
   platformUserId: string
   userId: string
-  isPiscineStudent?: boolean
-  isCursusStudent?: boolean
+  cursusStatus?: FortyTwoCursusStatus
   createdAt: string
   updatedAt: string
 }

--- a/frontend/src/app/actions/social-accounts.ts
+++ b/frontend/src/app/actions/social-accounts.ts
@@ -6,6 +6,8 @@ export interface SocialAccount {
   username: string
   platformUserId: string
   userId: string
+  isPiscineStudent?: boolean
+  isCursusStudent?: boolean
   createdAt: string
   updatedAt: string
 }

--- a/frontend/src/components/event-navbar.tsx
+++ b/frontend/src/components/event-navbar.tsx
@@ -49,11 +49,10 @@ export default function EventNavbar({
     const items = [
       { name: 'Info', path: `/events/${eventId}` },
       { name: 'Teams', path: `/events/${eventId}/teams` },
+      { name: 'My Team', path: `/events/${eventId}/my-team` },
     ]
 
     if (isUserRegistered) {
-      items.push({ name: 'My Team', path: `/events/${eventId}/my-team` })
-
       if (hasStarted) {
         items.push({
           name: 'Unit Builder',

--- a/frontend/src/lib/constants/cursus-status.ts
+++ b/frontend/src/lib/constants/cursus-status.ts
@@ -1,0 +1,5 @@
+export enum FortyTwoCursusStatus {
+  NONE = 'NONE',
+  PISCINE = 'PISCINE',
+  CURSUS = 'CURSUS',
+}

--- a/frontend/src/lib/constants/event-audience.ts
+++ b/frontend/src/lib/constants/event-audience.ts
@@ -1,0 +1,5 @@
+export enum EventAudience {
+  PISCINE = 'PISCINE',
+  CURSUS = 'CURSUS',
+  BOTH = 'BOTH',
+}

--- a/frontend/src/routes/events/$id/my-team.tsx
+++ b/frontend/src/routes/events/$id/my-team.tsx
@@ -171,7 +171,8 @@ function MyTeamRoute() {
   if (
     eventQuery.isPending ||
     myTeamQuery.isPending ||
-    isRegisteredQuery.isPending
+    isRegisteredQuery.isPending ||
+    fortyTwoAccountQuery.isLoading
   ) {
     return (
       <main className="flex min-h-[45vh] items-center justify-center">

--- a/frontend/src/routes/events/$id/my-team.tsx
+++ b/frontend/src/routes/events/$id/my-team.tsx
@@ -4,7 +4,12 @@ import { createFileRoute } from '@tanstack/react-router'
 import type { AxiosError } from 'axios'
 import { useState } from 'react'
 import axiosInstance from '@/app/actions/axios'
-import { getEventById, getEventGithubOrg } from '@/app/actions/event'
+import {
+  getEventById,
+  getEventGithubOrg,
+  isUserRegisteredForEvent,
+} from '@/app/actions/event'
+import { getSocialAccountByPlatform } from '@/app/actions/social-accounts'
 import {
   acceptTeamInvite,
   declineTeamInvite,
@@ -24,6 +29,8 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Spinner } from '@/components/ui/spinner'
+import { EventAudience } from '@/lib/constants/event-audience'
+import { OAUTH_PROVIDERS } from '@/lib/constants/oauth'
 import { validateTeamName } from '@/lib/utils/validation'
 
 export const Route = createFileRoute('/events/$id/my-team')({
@@ -41,6 +48,18 @@ function MyTeamRoute() {
   const eventQuery = useQuery({
     queryKey: ['event', id],
     queryFn: async () => getEventById(id),
+  })
+  const isRegisteredQuery = useQuery({
+    queryKey: ['event', id, 'is-user-registered'],
+    queryFn: async () => isUserRegisteredForEvent(id),
+  })
+  const fortyTwoAccountQuery = useQuery({
+    queryKey: ['social-accounts', OAUTH_PROVIDERS.FORTY_TWO],
+    queryFn: () => getSocialAccountByPlatform(OAUTH_PROVIDERS.FORTY_TWO),
+    enabled:
+      eventQuery.data?.audience !== undefined &&
+      eventQuery.data.audience !== EventAudience.BOTH &&
+      isRegisteredQuery.data === false,
   })
   const myTeamQuery = useQuery<Team | null>({
     queryKey: myTeamQueryKey(id),
@@ -149,7 +168,11 @@ function MyTeamRoute() {
     },
   })
 
-  if (eventQuery.isPending || myTeamQuery.isPending) {
+  if (
+    eventQuery.isPending ||
+    myTeamQuery.isPending ||
+    isRegisteredQuery.isPending
+  ) {
     return (
       <main className="flex min-h-[45vh] items-center justify-center">
         <Spinner />
@@ -163,6 +186,28 @@ function MyTeamRoute() {
         <Alert variant="destructive">
           <AlertTitle>Event unavailable</AlertTitle>
           <AlertDescription>Could not load event details.</AlertDescription>
+        </Alert>
+      </main>
+    )
+  }
+
+  if (!isRegisteredQuery.data) {
+    const audience = eventQuery.data.audience
+    const audienceLabel =
+      audience === EventAudience.PISCINE ? 'piscine' : '42cursus'
+
+    const description =
+      audience !== EventAudience.BOTH
+        ? fortyTwoAccountQuery.data
+          ? `This event is only open to ${audienceLabel} students, and your linked 42 intra account doesn't meet that requirement.`
+          : `This event is only open to ${audienceLabel} students. Link your 42 intra account in your profile settings to check your eligibility.`
+        : "You haven't joined this event yet. Head to the Info tab to join."
+
+    return (
+      <main className="container mx-auto max-w-4xl px-4 py-8">
+        <Alert>
+          <AlertTitle>Team unavailable</AlertTitle>
+          <AlertDescription>{description}</AlertDescription>
         </Alert>
       </main>
     )

--- a/frontend/src/routes/events/create.tsx
+++ b/frontend/src/routes/events/create.tsx
@@ -21,10 +21,18 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { useSession } from '@/lib/auth'
+import { EventAudience } from '@/lib/constants/event-audience'
 import { cn } from '@/lib/utils'
 
 export const Route = createFileRoute('/events/create')({
@@ -56,6 +64,7 @@ const formSchema = z
     gameConfig: z.string().min(1, 'Game config is required'),
     serverConfig: z.string().min(1, 'Server config is required'),
     isPrivate: z.boolean(),
+    audience: z.enum(EventAudience),
   })
   .refine((value) => value.maxTeamSize >= value.minTeamSize, {
     message: 'Max team size must be at least the min team size',
@@ -86,6 +95,7 @@ const defaultValues: FormValues = {
   gameConfig: '',
   serverConfig: '',
   isPrivate: false,
+  audience: EventAudience.BOTH,
 }
 
 function parseGitHubRepo(url: string): { owner: string; repo: string } | null {
@@ -251,6 +261,7 @@ function CreateEventRoute() {
         gameConfig: values.gameConfig,
         serverConfig: values.serverConfig,
         isPrivate: values.isPrivate,
+        audience: values.audience,
       }
 
       return createEvent(payload)
@@ -545,6 +556,35 @@ function CreateEventRoute() {
                       onCheckedChange={field.handleChange}
                     />
                   </div>
+                )}
+              />
+
+              <form.Field
+                name="audience"
+                children={(field) => (
+                  <TextField errors={field.state.meta.errors} label="Audience">
+                    <Select
+                      value={field.state.value}
+                      onValueChange={(value: EventAudience) =>
+                        field.handleChange(value)
+                      }
+                    >
+                      <SelectTrigger id={field.name}>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={EventAudience.BOTH}>
+                          Piscine &amp; 42cursus
+                        </SelectItem>
+                        <SelectItem value={EventAudience.PISCINE}>
+                          Piscine only
+                        </SelectItem>
+                        <SelectItem value={EventAudience.CURSUS}>
+                          42cursus only
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </TextField>
                 )}
               />
             </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events can now target all participants, Piscine students, or 42cursus students via a new audience setting.
  * Event creators can select the audience when creating events (and it’s supported in event settings updates).
  * “My Team” now gates access based on registration/eligibility and shows audience-aware messaging.
  * 42 account details now include Piscine and 42cursus enrollment flags.

* **Bug Fixes**
  * Improved and more consistent messaging when users cannot access an event’s team area due to audience eligibility/registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->