### PR TITLE
Restore case-insensitive team search on the event teams overview

### DIFF
--- a/api/src/team/team-search.spec.ts
+++ b/api/src/team/team-search.spec.ts
@@ -21,6 +21,47 @@ import type { TeamEntity } from "./entities/team.entity";
 import { TeamService } from "./team.service";
 
 describe("TeamService.getSearchedTeamsForEvent", () => {
+  it("searches team names without regard to case", async () => {
+    const queryBuilder = {
+      innerJoin: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawAndEntities: jest.fn().mockResolvedValue({
+        entities: [],
+        raw: [],
+      }),
+    };
+    const service = Object.create(TeamService.prototype) as TeamService;
+
+    Reflect.set(service, "teamRepository", {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    });
+    Reflect.set(service, "eventService", {
+      isEventAdmin: jest.fn().mockResolvedValue(false),
+    });
+    Reflect.set(service, "matchService", {
+      calculateBuchholzPointsForTeams: jest.fn().mockResolvedValue(new Map()),
+    });
+    jest.spyOn(service, "getLocationTagsForTeams").mockResolvedValue(new Map());
+
+    await service.getSearchedTeamsForEvent(
+      "event-1",
+      "tEaM oNe",
+      undefined,
+      undefined,
+      "user-1",
+    );
+
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      "team.name ILIKE :searchName",
+      { searchName: "%tEaM oNe%" },
+    );
+  });
+
   it("returns the persisted Buchholz score for the admin reveal view", async () => {
     const team = {
       id: "team-1",

--- a/api/src/team/team.service.ts
+++ b/api/src/team/team.service.ts
@@ -580,7 +580,7 @@ export class TeamService {
     query.addSelect("COUNT(DISTINCT user.id)", "user_count").groupBy("team.id");
 
     if (searchName) {
-      query.andWhere("team.name LIKE :searchName", {
+      query.andWhere("team.name ILIKE :searchName", {
         searchName: `%${searchName}%`,
       });
     }

--- a/frontend/src/routes/events/$id/teams.tsx
+++ b/frontend/src/routes/events/$id/teams.tsx
@@ -6,13 +6,15 @@ import {
   useLocation,
   useNavigate,
 } from '@tanstack/react-router'
-import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react'
+import { ArrowDown, ArrowUp, ArrowUpDown, Search } from 'lucide-react'
 import { useState } from 'react'
 import { getTeamsForEventTable } from '@/app/actions/team'
 import { LocationTags } from '@/components/team'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import {
   Table,
   TableBody,
@@ -80,12 +82,26 @@ function TeamsRoute() {
       location.pathname === `/events/${id}/teams/`,
   })
   const navigate = useNavigate()
+  const [searchQuery, setSearchQuery] = useState('')
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, 300).trim()
   const [sortColumn, setSortColumn] = useState<SortColumn>('name')
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const teamsQuery = useQuery({
-    queryKey: ['event', id, 'teams', sortColumn, sortDirection],
+    queryKey: [
+      'event',
+      id,
+      'teams',
+      debouncedSearchQuery,
+      sortColumn,
+      sortDirection,
+    ],
     queryFn: () =>
-      getTeamsForEventTable(id, undefined, sortColumn, sortDirection),
+      getTeamsForEventTable(
+        id,
+        debouncedSearchQuery || undefined,
+        sortColumn,
+        sortDirection,
+      ),
     placeholderData: (previousData) => previousData,
   })
 
@@ -122,8 +138,19 @@ function TeamsRoute() {
   return (
     <main className="container mx-auto max-w-7xl px-4 py-8">
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-col gap-4 space-y-0 sm:flex-row sm:items-center sm:justify-between">
           <CardTitle>Teams</CardTitle>
+          <div className="relative w-full sm:max-w-xs">
+            <Search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              aria-label="Search teams by name"
+              className="pl-9"
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Search teams by name..."
+              type="search"
+              value={searchQuery}
+            />
+          </div>
         </CardHeader>
         <CardContent>
           <Table>
@@ -162,7 +189,9 @@ function TeamsRoute() {
                     colSpan={3}
                     className="text-center text-muted-foreground"
                   >
-                    No teams found
+                    {debouncedSearchQuery
+                      ? 'No teams match your search.'
+                      : 'No teams found'}
                   </TableCell>
                 </TableRow>
               ) : (


### PR DESCRIPTION
## Summary

- Add debounced team-name search to the event teams overview.
- Include the search term in query caching and API requests.
- Use PostgreSQL `ILIKE` for case-insensitive matching.
- Add an empty-state message for searches with no matches.

## Testing

- Added a unit test covering case-insensitive team-name search parameters.