### PR TITLE
Add per-event gambling enablement toggle

### DIFF
--- a/api/db/migrations/1784395000000-event-gambling-enabled.ts
+++ b/api/db/migrations/1784395000000-event-gambling-enabled.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class EventGamblingEnabled1784395000000 implements MigrationInterface {
+  name = "EventGamblingEnabled1784395000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "events" ADD "gamblingEnabled" boolean NOT NULL DEFAULT true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "events" DROP COLUMN "gamblingEnabled"`,
+    );
+  }
+}

--- a/api/src/event/dtos/updateEventSettingsDto.ts
+++ b/api/src/event/dtos/updateEventSettingsDto.ts
@@ -19,6 +19,11 @@ export class UpdateEventSettingsDto {
   @IsBoolean()
   processQueue?: boolean;
 
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  gamblingEnabled?: boolean;
+
   @ApiPropertyOptional({ minimum: 1 })
   @IsOptional()
   @IsInt()

--- a/api/src/event/entities/event.entity.ts
+++ b/api/src/event/entities/event.entity.ts
@@ -59,6 +59,9 @@ export class EventEntity {
   @Column({ default: true })
   processQueue: boolean;
 
+  @Column({ default: true })
+  gamblingEnabled: boolean;
+
   @Column({ default: 5 })
   maxQueueCredits: number;
 

--- a/api/src/event/event.service.ts
+++ b/api/src/event/event.service.ts
@@ -464,6 +464,7 @@ export class EventService {
     settings: {
       canCreateTeam?: boolean;
       processQueue?: boolean;
+      gamblingEnabled?: boolean;
       maxQueueCredits?: number;
       queueCreditIntervalMinutes?: number;
       isPrivate?: boolean;
@@ -493,6 +494,7 @@ export class EventService {
     const booleanFields = [
       "canCreateTeam",
       "processQueue",
+      "gamblingEnabled",
       "isPrivate",
     ] as const;
     for (const field of booleanFields) {

--- a/api/src/gambling/gambling-access.spec.ts
+++ b/api/src/gambling/gambling-access.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException } from "@nestjs/common";
 import {
   hasGamblingStarted,
+  requireGamblingEnabled,
   requireGamblingStarted,
   requireGamblingTeam,
 } from "./gambling-access";
@@ -21,6 +22,13 @@ describe("gambling access", () => {
     ).toThrow(
       new BadRequestException("Gambling is available after the event starts."),
     );
+  });
+
+  it("rejects gambling when it is disabled for the event", () => {
+    expect(() => requireGamblingEnabled(false)).toThrow(
+      new BadRequestException("Gambling is disabled for this event."),
+    );
+    expect(() => requireGamblingEnabled(true)).not.toThrow();
   });
 
   it("returns an existing team", () => {

--- a/api/src/gambling/gambling-access.ts
+++ b/api/src/gambling/gambling-access.ts
@@ -11,6 +11,11 @@ export function requireGamblingStarted(startDate: Date, now = new Date()) {
     );
 }
 
+export function requireGamblingEnabled(gamblingEnabled: boolean) {
+  if (!gamblingEnabled)
+    throw new BadRequestException("Gambling is disabled for this event.");
+}
+
 export function requireGamblingTeam<T>(team: T | null): T {
   if (!team)
     throw new BadRequestException(

--- a/api/src/gambling/gambling.service.ts
+++ b/api/src/gambling/gambling.service.ts
@@ -31,6 +31,7 @@ import {
 } from "./gambling-bet-summary";
 import {
   hasGamblingStarted,
+  requireGamblingEnabled,
   requireGamblingStarted,
   requireGamblingTeam,
 } from "./gambling-access";
@@ -208,6 +209,7 @@ export class GamblingService {
     await this.advanceEvent(eventId);
     await this.dataSource.transaction(async (manager) => {
       await this.lockEvent(manager, eventId);
+      await this.getStartedEvent(manager, eventId);
       const round = await this.getLatestRoundWithManager(manager, eventId);
       if (
         !round ||
@@ -391,9 +393,24 @@ export class GamblingService {
   ): Promise<GamblingAdvanceAction> {
     await this.lockEvent(manager, eventId);
     const event = await manager.findOneOrFail(EventEntity, {
-      select: { id: true, startDate: true },
+      select: { id: true, startDate: true, gamblingEnabled: true },
       where: { id: eventId },
     });
+    if (!event.gamblingEnabled) {
+      const round = await this.getLatestRoundWithManager(manager, eventId);
+      if (
+        round?.phase === GamblingRoundPhase.PLAYING &&
+        round.match?.state === MatchState.FINISHED &&
+        round.match.winner
+      ) {
+        return {
+          type: "settle",
+          matchId: round.match.id,
+          winnerId: round.match.winner.id,
+        };
+      }
+      return null;
+    }
     if (!hasGamblingStarted(event.startDate)) return null;
 
     const round = await this.getOrCreateCurrentRound(manager, eventId);
@@ -612,9 +629,15 @@ export class GamblingService {
 
   private async getStartedEvent(manager: EntityManager, eventId: string) {
     const event = await manager.findOneOrFail(EventEntity, {
-      select: { id: true, startDate: true, maxQueueCredits: true },
+      select: {
+        id: true,
+        startDate: true,
+        maxQueueCredits: true,
+        gamblingEnabled: true,
+      },
       where: { id: eventId },
     });
+    requireGamblingEnabled(event.gamblingEnabled);
     requireGamblingStarted(event.startDate);
     return event;
   }

--- a/frontend/src/app/actions/event.ts
+++ b/frontend/src/app/actions/event.ts
@@ -19,6 +19,7 @@ export interface Event {
   canCreateTeam: boolean
   lockedAt: string | null
   processQueue: boolean
+  gamblingEnabled: boolean
   maxQueueCredits: number
   queueCreditIntervalMinutes: number
   monorepoUrl?: string
@@ -141,6 +142,7 @@ export async function updateEventSettings(
   settings: {
     canCreateTeam?: boolean
     processQueue?: boolean
+    gamblingEnabled?: boolean
     maxQueueCredits?: number
     queueCreditIntervalMinutes?: number
     isPrivate?: boolean

--- a/frontend/src/components/event-navbar.tsx
+++ b/frontend/src/components/event-navbar.tsx
@@ -74,7 +74,9 @@ export default function EventNavbar({
 
       if (hasStarted && effectiveHasTeam) {
         items.push({ name: 'Match Making', path: `/events/${eventId}/queue` })
-        items.push({ name: 'Gambling', path: `/events/${eventId}/gambling` })
+        if (event.gamblingEnabled) {
+          items.push({ name: 'Gambling', path: `/events/${eventId}/gambling` })
+        }
       }
     }
 
@@ -95,6 +97,7 @@ export default function EventNavbar({
     isEventAdmin,
     hasStarted,
     supportsUnitBuilder,
+    event.gamblingEnabled,
   ])
 
   return (

--- a/frontend/src/routes/events/$id/dashboard.tsx
+++ b/frontend/src/routes/events/$id/dashboard.tsx
@@ -121,6 +121,7 @@ const SETTINGS_FIELDS = [
   'location',
   'canCreateTeam',
   'processQueue',
+  'gamblingEnabled',
   'maxQueueCredits',
   'queueCreditIntervalMinutes',
   'isPrivate',
@@ -941,7 +942,7 @@ function SettingsTab({
 
           <div className="space-y-4 border-t pt-4">
             <h3 className="text-sm font-semibold">Toggles</h3>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
               <SettingSwitch
                 id="canCreateTeam"
                 label="Allow Team Creation"
@@ -956,6 +957,14 @@ function SettingsTab({
                 checked={pendingSettings.processQueue || false}
                 onCheckedChange={(value) =>
                   updatePendingSetting('processQueue', value)
+                }
+              />
+              <SettingSwitch
+                id="gamblingEnabled"
+                label="Enable Gambling"
+                checked={pendingSettings.gamblingEnabled ?? true}
+                onCheckedChange={(value) =>
+                  updatePendingSetting('gamblingEnabled', value)
                 }
               />
               <SettingSwitch


### PR DESCRIPTION
## Summary

- Add a per-event `gamblingEnabled` setting with database migration and event settings API support.
- Hide gambling navigation when disabled and block gambling actions server-side.
- Preserve settlement of completed matches when gambling is disabled.
- Add coverage for the disabled-gambling access guard.

## Testing

- Added unit coverage for gambling access validation.
- Not run (not requested)