### PR TITLE
Reset wiki content scroll position when navigating between pages

### DIFF
--- a/frontend/src/components/wiki/WikiLayout.test.tsx
+++ b/frontend/src/components/wiki/WikiLayout.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { WikiLayout } from './WikiLayout'
+
+vi.mock('@/lib/router-hooks', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/contexts/NavbarContext', () => ({
+  useNavbar: () => ({ isBasicNavbarMenuOpen: false }),
+}))
+
+vi.mock('./VersionSelector', () => ({
+  VersionSelector: () => null,
+}))
+
+vi.mock('./WikiNavigation', () => ({
+  WikiNavigation: () => null,
+}))
+
+vi.mock('./WikiSearch', () => ({
+  WikiSearch: () => null,
+}))
+
+afterEach(cleanup)
+
+describe('WikiLayout', () => {
+  it('resets the wiki content scroll position when the page changes', () => {
+    const { container, rerender } = render(
+      <WikiLayout navigation={[]} currentSlug={['getting-started']}>
+        First page
+      </WikiLayout>,
+    )
+    const content = container.querySelector<HTMLElement>('.main-wiki-content')!
+    content.scrollTop = 480
+
+    rerender(
+      <WikiLayout navigation={[]} currentSlug={['configuration']}>
+        Second page
+      </WikiLayout>,
+    )
+
+    expect(content.scrollTop).toBe(0)
+  })
+
+  it('preserves the scroll position when the current page rerenders', () => {
+    const { container, rerender } = render(
+      <WikiLayout navigation={[]} currentSlug={['getting-started']}>
+        First render
+      </WikiLayout>,
+    )
+    const content = container.querySelector<HTMLElement>('.main-wiki-content')!
+    content.scrollTop = 480
+
+    rerender(
+      <WikiLayout navigation={[]} currentSlug={['getting-started']}>
+        Updated render
+      </WikiLayout>,
+    )
+
+    expect(content.scrollTop).toBe(480)
+  })
+})

--- a/frontend/src/components/wiki/WikiLayout.tsx
+++ b/frontend/src/components/wiki/WikiLayout.tsx
@@ -35,6 +35,17 @@ export function WikiLayout({
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
   const { isBasicNavbarMenuOpen } = useNavbar()
   const sidebarRef = useRef<HTMLElement>(null)
+  const contentRef = useRef<HTMLElement>(null)
+  const pageKey = `${currentVersion}/${currentSlug.join('/')}`
+
+  // The wiki scrolls inside its own container, which persists between client-side
+  // route changes. Reset that container when the page changes; hash-only changes
+  // keep their position so heading navigation can handle them separately.
+  useLayoutEffect(() => {
+    if (contentRef.current) {
+      contentRef.current.scrollTop = 0
+    }
+  }, [pageKey])
 
   // Save sidebar scroll position on scroll (debounced)
   useEffect(() => {
@@ -285,7 +296,10 @@ export function WikiLayout({
           </div>
         </header>
 
-        <main className="main-wiki-content min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain p-4 sm:p-6">
+        <main
+          ref={contentRef}
+          className="main-wiki-content min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain p-4 sm:p-6"
+        >
           <div
             className="mx-auto max-w-4xl"
             style={{ viewTransitionName: 'wiki-content' }}


### PR DESCRIPTION
## Summary

- Reset the wiki content container scroll position when the page or version changes.
- Preserve scroll position for rerenders and hash-only navigation.
- Add regression tests covering page changes and rerenders.

## Testing

- Added Vitest and Testing Library coverage for wiki scroll behavior.